### PR TITLE
Add reference to libedit at end of command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ bin/call_lisp: tools/call_lisp.o bin/libfunlisp.a
 	$(CC) $(CFLAGS) $^ -o $@
 
 bin/funlisp: tools/funlisp.o bin/libfunlisp.a
-	$(CC) $(CFLAGS) -ledit $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@ -ledit 
 
 bin/example_list_append: tools/example_list_append.o bin/libfunlisp.a
 	$(CC) $(CFLAGS) $^ -o $@


### PR DESCRIPTION
Previously, the reference to libedit was at the middle of the
command and this prevented compilation giving undefined
reference errors. Adding the reference at the end of the command
fixes the issue and compiles successfully(on Linux with gcc).